### PR TITLE
fix : dockerfile 경로 수정 #10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /install/packages /usr/local/
 
 COPY . .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## #️⃣ Issue Number

- #10 

## 📝 요약(Summary)

Dockerfile의 경로가 잘못되어있어서 계속 main을 못찾아서 ai-server가 에러를 발생시키면서 실행되지 않는 것을 발견하고 수정하였습니다.

## 💬 공유사항 to 리뷰어



## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).